### PR TITLE
fix: resolve terraform plan failures

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ module "eks" {
   cluster_encryption_config = var.enable_cluster_encryption ? {
     resources        = ["secrets"]
     provider_key_arn = aws_kms_key.eks[0].arn
-  } : {}
+  } : null
 
   # CloudWatch logging
   cluster_enabled_log_types              = var.cluster_enabled_log_types

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,8 +34,8 @@ output "nat_gateway_ips" {
 # ============================================================================
 
 output "cluster_id" {
-  description = "The ID of the EKS cluster"
-  value       = module.eks.cluster_id
+  description = "The ID of the EKS cluster (same as cluster name in EKS)"
+  value       = module.eks.cluster_name
 }
 
 output "cluster_name" {


### PR DESCRIPTION
## Summary
- Fix Inconsistent conditional result types in main.tf cluster_encryption_config ternary (use null instead of {})
- Fix cluster_id output referencing removed EKS module v20.x attribute (use cluster_name)
- Fix pipe failure masking in apply workflow (set -o pipefail)
- Fix IAM role name_prefix exceeding 38-char limit
- Add S3 native state locking backend
- Implement Claude AI code review on PRs

## Test plan
- [ ] Merge PR and verify apply workflow succeeds on main
- [ ] Confirm all 60 resources are created
- [ ] Add ANTHROPIC_API_KEY secret to enable Claude AI code review

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>