### PR TITLE
feat: add workflow_dispatch to terraform apply workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(aws s3api:*)",
+      "Bash(gh repo:*)",
+      "Bash(winget install:*)",
+      "Bash(choco install:*)",
+      "Bash(scoop install:*)",
+      "Bash(export PATH=\"$PATH:/c/Program Files/GitHub CLI\")",
+      "Bash(gh --version)",
+      "Bash(gh auth:*)",
+      "Bash(git init:*)",
+      "Bash(git remote:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Bash(terraform init:*)",
+      "Bash(gh run:*)",
+      "Bash(curl -s \"https://registry.terraform.io/v1/modules/terraform-aws-modules/eks/aws/versions\")",
+      "Bash(python3 -c \"import sys,json; versions=[v[''''version''''] for v in json.load\\(sys.stdin\\)[''''modules''''][0][''''versions'''']]; print\\(''''\\\\n''''.join\\([v for v in versions if v.startswith\\(''''20.''''\\)]\\)[:500]\\)\")",
+      "Bash(curl -s \"https://registry.terraform.io/v1/modules/terraform-aws-modules/eks/aws\")",
+      "Bash(curl -s \"https://registry.terraform.io/v1/modules/terraform-aws-modules/eks/aws/20.31.6\")",
+      "Bash(terraform validate:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(kubectl get:*)",
+      "Bash(aws sts:*)",
+      "Bash(npx --version)",
+      "Read(//c/Users/tejas/.claude/**)",
+      "Bash(npx -y mcp-server-kubernetes --help)"
+    ],
+    "additionalDirectories": [
+      "C:\\Users\\tejas\\.claude"
+    ]
+  }
+}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -9,6 +9,12 @@ on:
       - '**.tf'
       - '**.tfvars'
       - '.github/workflows/terraform-apply.yml'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual apply (e.g. recreate infra after destroy)'
+        required: false
+        default: 'Manual trigger'
 
 # Prevent concurrent deployments
 concurrency:

--- a/README.md
+++ b/README.md
@@ -392,3 +392,4 @@ MIT License - See LICENSE file for details
 ---
 
 **Generated with Claude Code** | **AWS Well-Architected** | **Zero-Trust Security**
+


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `terraform-apply.yml` so infra can be recreated manually without needing a dummy `.tf` commit
- Includes an optional `reason` input field for context when triggering manually

## How to use after merge

**GitHub UI:** Actions → Terraform Auto-Apply → Run workflow → (optionally add a reason) → Run

**GitHub CLI:**
```bash
gh workflow run "Terraform Auto-Apply" --ref main
# or with a reason
gh workflow run "Terraform Auto-Apply" --ref main -f reason="Recreate infra after destroy"
```

## Test plan

- [ ] Merge PR
- [ ] Go to Actions → Terraform Auto-Apply → Run workflow
- [ ] Confirm plan and apply steps execute successfully
- [ ] Verify EKS cluster is recreated and reaches ACTIVE state

🤖 Generated with [Claude Code](https://claude.com/claude-code)